### PR TITLE
Fix CI lint: use schemaName and tighten types

### DIFF
--- a/src/converter.ts
+++ b/src/converter.ts
@@ -353,7 +353,7 @@ export class Eval2OtelConverter {
     if (!evalResult.agent?.steps) return;
 
     evalResult.agent.steps.forEach((step, index) => {
-      const attributes: Record<string, any> = {
+      const attributes: Record<string, string | number | boolean> = {
         'gen_ai.agent.step.index': index,
         'gen_ai.agent.step.name': step.name,
         'gen_ai.agent.step.status': step.status,
@@ -380,7 +380,7 @@ export class Eval2OtelConverter {
     if (!evalResult.rag?.chunks) return;
 
     evalResult.rag.chunks.forEach((chunk, index) => {
-      const attributes: Record<string, any> = {
+      const attributes: Record<string, string | number | boolean> = {
         'gen_ai.rag.chunk.index': index,
         'gen_ai.rag.chunk.id': chunk.id,
         'gen_ai.rag.chunk.source': chunk.source,

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -137,10 +137,10 @@ export class Eval2OtelValidation {
   /**
    * Add validation events to a span
    */
-  addValidationEvents(
+  addValidationEvents<T>(
     span: Span,
     schemaName: string,
-    result: ValidationResult<any>
+    result: ValidationResult<T>
   ): void {
     if (result.success) {
       span.addEvent('gen_ai.validation.success', {
@@ -170,7 +170,7 @@ export class Eval2OtelValidation {
   /**
    * Get validation metrics for tracking
    */
-  getValidationMetrics(result: ValidationResult<any>): Record<string, number> {
+  getValidationMetrics<T>(result: ValidationResult<T>): Record<string, number> {
     return {
       'validation.success': result.success ? 1 : 0,
       'validation.attempts': result.attempts,
@@ -279,6 +279,7 @@ export function createValidationWrapper<T>(
   return (evalResult: EvalResult): EvalResult & { 
     validatedOutput?: T;
     validationMetrics?: Record<string, number>;
+    validationSchema?: string;
   } => {
     const validation = new Eval2OtelValidation();
     const result = validation.withSchema(schema, evalResult);
@@ -288,12 +289,14 @@ export function createValidationWrapper<T>(
         ...evalResult,
         validatedOutput: result.validation.data,
         validationMetrics: validation.getValidationMetrics(result.validation),
+        validationSchema: schemaName,
       };
     }
     
     return {
       ...evalResult,
       validationMetrics: validation.getValidationMetrics(result.validation!),
+      validationSchema: schemaName,
     };
   };
 }


### PR DESCRIPTION
This PR fixes the CI failure due to ESLint by:\n\n- Using the `schemaName` parameter in `createValidationWrapper` and surfacing it as `validationSchema` in the returned object\n- Tightening types to remove `any` usage warnings:\n  - Make validation methods generic instead of `any` (`addValidationEvents`, `getValidationMetrics`)\n  - Use `Record<string, string | number | boolean>` for OpenTelemetry event attributes in converter\n\nLocal verification:\n- Lint passes (no errors)\n- Tests pass (30/30)\n- Build succeeds\n\nThis should unblock the GitHub Actions CI pipeline.