### PR TITLE
Per-field redaction hooks (messages, tool arguments)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ const evalResult: EvalResult = {
   },
   
   performance: {
-    duration: 1500, // milliseconds
+    duration: 1.5, // seconds
   },
 };
 
@@ -234,6 +234,8 @@ interface OtelConfig {
   environment?: string;          // Deployment environment
   captureContent?: boolean;      // Opt-in for sensitive content
   sampleContentRate?: number;    // Content sampling rate (0.0-1.0)
+  contentMaxLength?: number;     // Optional: truncate captured content (characters)
+  contentSampler?: (evalResult: EvalResult) => boolean; // Optional custom sampler
   redact?: (content: string) => string | null; // Custom redaction
   endpoint?: string;            // OpenTelemetry endpoint
   resourceAttributes?: Record<string, string | number | boolean>;
@@ -280,7 +282,7 @@ eval2otel follows OpenTelemetry GenAI semantic conventions. Here's how `EvalResu
 | `gen_ai.system.message` | System message | `content`, `role`, `index` |
 | `gen_ai.user.message` | User message | `content`, `role`, `index` |
 | `gen_ai.assistant.message` | Assistant response | `content`, `role`, `choice.index` |
-| `gen_ai.tool.message` | Tool call/result | `tool.name`, `tool.call_id`, `arguments` |
+| `gen_ai.tool.message` | Tool call/result | `gen_ai.tool.name`, `gen_ai.tool.call.id`, `gen_ai.tool.arguments`, `gen_ai.response.choice.index` |
 
 ### Metrics
 
@@ -293,6 +295,12 @@ eval2otel follows OpenTelemetry GenAI semantic conventions. Here's how `EvalResu
 | `eval.custom.metric` | Histogram | `1` | Custom quality metrics |
 
 All metrics include attributes for `gen_ai.operation.name`, `gen_ai.request.model`, `gen_ai.system`, and `deployment.environment`.
+
+#### Units
+
+- Client and server durations are in seconds.
+- Agent step and validation durations are in milliseconds.
+- Ensure inputs match expected units to avoid skewed metrics.
 
 ## Privacy & Security
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -165,6 +165,12 @@ export interface OtelConfig {
   /** Redaction function for sensitive content */
   redact?: (content: string) => string | null;
   
+  /** Optional redaction hook for message content with role context */
+  redactMessageContent?: (content: string, info: { role: string }) => string | null;
+
+  /** Optional redaction hook for tool arguments with function context */
+  redactToolArguments?: (argsJson: string, info: { functionName: string; callId?: string }) => string | null;
+  
   /** OTLP endpoint */
   endpoint?: string;
   


### PR DESCRIPTION
Introduce granular redaction hooks for better privacy control:\n\n- Add `redactMessageContent(content, { role })`\n- Add `redactToolArguments(argsJson, { functionName, callId })`\n- Converter uses these hooks with context; falls back to global `redact`\n\nNo breaking changes; defaults preserve prior behavior. Lint, tests, and build pass.