### PR TITLE
Add emitOperationalMetadata flag to suppress events

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ interface OtelConfig {
   sampleContentRate?: number;    // Content sampling rate (0.0-1.0)
   contentMaxLength?: number;     // Optional: truncate captured content (characters)
   contentSampler?: (evalResult: EvalResult) => boolean; // Optional custom sampler
+  emitOperationalMetadata?: boolean; // Suppress conversation/choice/agent/RAG events when false (default true)
   redact?: (content: string) => string | null; // Custom redaction
   endpoint?: string;            // OpenTelemetry endpoint
   resourceAttributes?: Record<string, string | number | boolean>;

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ const evalResult: EvalResult = {
   },
   
   performance: {
-    duration: 1500, // milliseconds
+    duration: 1.5, // seconds
   },
 };
 
@@ -234,6 +234,8 @@ interface OtelConfig {
   environment?: string;          // Deployment environment
   captureContent?: boolean;      // Opt-in for sensitive content
   sampleContentRate?: number;    // Content sampling rate (0.0-1.0)
+  contentMaxLength?: number;     // Optional: truncate captured content (characters)
+  contentSampler?: (evalResult: EvalResult) => boolean; // Optional custom sampler
   redact?: (content: string) => string | null; // Custom redaction
   endpoint?: string;            // OpenTelemetry endpoint
   resourceAttributes?: Record<string, string | number | boolean>;
@@ -280,7 +282,7 @@ eval2otel follows OpenTelemetry GenAI semantic conventions. Here's how `EvalResu
 | `gen_ai.system.message` | System message | `content`, `role`, `index` |
 | `gen_ai.user.message` | User message | `content`, `role`, `index` |
 | `gen_ai.assistant.message` | Assistant response | `content`, `role`, `choice.index` |
-| `gen_ai.tool.message` | Tool call/result | `tool.name`, `tool.call_id`, `arguments` |
+| `gen_ai.tool.message` | Tool call/result | `gen_ai.tool.name`, `gen_ai.tool.call.id`, `gen_ai.tool.arguments`, `gen_ai.response.choice.index` |
 
 ### Metrics
 
@@ -293,6 +295,12 @@ eval2otel follows OpenTelemetry GenAI semantic conventions. Here's how `EvalResu
 | `eval.custom.metric` | Histogram | `1` | Custom quality metrics |
 
 All metrics include attributes for `gen_ai.operation.name`, `gen_ai.request.model`, `gen_ai.system`, and `deployment.environment`.
+
+#### Units
+
+- Client and server durations are in seconds.
+- Agent step and validation durations are in milliseconds.
+- Ensure inputs match expected units to avoid skewed metrics.
 
 ## Privacy & Security
 

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -47,23 +47,23 @@ export class Eval2OtelConverter {
       span.setStatus({ code: SpanStatusCode.OK });
     }
 
-    // Add conversation events if present and content capture is enabled
-    if (validated.conversation && this.shouldCaptureContent(validated)) {
+    // Add conversation events if present and allowed
+    if (validated.conversation && this.shouldCaptureContent(validated) && (this.config.emitOperationalMetadata !== false)) {
       this.addConversationEvents(span, validated);
     }
 
-    // Add choice events for response
-    if (validated.response.choices && this.shouldCaptureContent(validated)) {
+    // Add choice events for response if allowed
+    if (validated.response.choices && this.shouldCaptureContent(validated) && (this.config.emitOperationalMetadata !== false)) {
       this.addChoiceEvents(span, validated);
     }
 
-    // Add agent step events
-    if (validated.agent?.steps && this.shouldCaptureContent(validated)) {
+    // Add agent step events if allowed
+    if (validated.agent?.steps && this.shouldCaptureContent(validated) && (this.config.emitOperationalMetadata !== false)) {
       this.addAgentStepEvents(span, validated);
     }
 
-    // Add RAG chunk events
-    if (validated.rag?.chunks && this.shouldCaptureContent(validated)) {
+    // Add RAG chunk events if allowed
+    if (validated.rag?.chunks && this.shouldCaptureContent(validated) && (this.config.emitOperationalMetadata !== false)) {
       this.addRAGChunkEvents(span, validated);
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -165,6 +165,12 @@ export interface OtelConfig {
   /** Redaction function for sensitive content */
   redact?: (content: string) => string | null;
   
+  /** Optional redaction hook for message content with role context */
+  redactMessageContent?: (content: string, info: { role: string }) => string | null;
+
+  /** Optional redaction hook for tool arguments with function context */
+  redactToolArguments?: (argsJson: string, info: { functionName: string; callId?: string }) => string | null;
+  
   /** OTLP endpoint */
   endpoint?: string;
   

--- a/src/types.ts
+++ b/src/types.ts
@@ -161,6 +161,9 @@ export interface OtelConfig {
   
   /** Optional sampler to decide if content should be captured for a given evaluation. */
   contentSampler?: (evalResult: EvalResult) => boolean;
+
+  /** Whether to emit operational metadata events (conversation, choices, agent, RAG). Default: true */
+  emitOperationalMetadata?: boolean;
   
   /** Redaction function for sensitive content */
   redact?: (content: string) => string | null;

--- a/test/converter-events.test.ts
+++ b/test/converter-events.test.ts
@@ -1,0 +1,154 @@
+import { trace } from '@opentelemetry/api';
+import { Eval2OtelConverter } from '../src/converter';
+import { EvalResult } from '../src/types';
+
+describe('Converter events', () => {
+  class FakeSpan {
+    public events: { name: string; attributes: Record<string, unknown> }[] = [];
+    addEvent(name: string, attributes: Record<string, unknown>) {
+      this.events.push({ name, attributes });
+    }
+    setStatus() {}
+    recordException() {}
+    end() {}
+  }
+  class FakeTracer {
+    public lastSpan: FakeSpan | null = null;
+    startSpan() {
+      this.lastSpan = new FakeSpan();
+      return this.lastSpan as any;
+    }
+  }
+
+  it('emits standardized tool event attributes and truncates content', () => {
+    const fakeTracer = new FakeTracer();
+    jest.spyOn(trace, 'getTracer').mockReturnValue(fakeTracer as any);
+
+    const converter = new Eval2OtelConverter({
+      serviceName: 'svc',
+      captureContent: true,
+      contentMaxLength: 10,
+      contentSampler: () => true,
+    });
+
+    const evalResult: EvalResult = {
+      id: 'id1',
+      timestamp: Date.now(),
+      model: 'gpt-4',
+      system: 'openai',
+      operation: 'chat',
+      request: { model: 'gpt-4' },
+      response: {
+        choices: [
+          {
+            index: 0,
+            finishReason: 'stop',
+            message: {
+              role: 'assistant',
+              content: 'this is a long content string',
+              toolCalls: [
+                {
+                  id: 'call1',
+                  type: 'function',
+                  function: {
+                    name: 'calc',
+                    arguments: { alpha: '0123456789012345' },
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      usage: {},
+      performance: { duration: 1 },
+    } as any;
+
+    converter.convertEvalResult(evalResult);
+    const span = fakeTracer.lastSpan!;
+    const toolEvent = span.events.find((e) => e.name === 'gen_ai.tool.message');
+    expect(toolEvent).toBeDefined();
+    expect(toolEvent!.attributes['gen_ai.tool.name']).toBe('calc');
+    expect(toolEvent!.attributes['gen_ai.tool.call.id']).toBe('call1');
+    expect(toolEvent!.attributes['gen_ai.response.choice.index']).toBe(0);
+    const args = String(toolEvent!.attributes['gen_ai.tool.arguments']);
+    expect(args.length).toBeLessThanOrEqual(10);
+
+    const assistantEvent = span.events.find((e) => e.name === 'gen_ai.assistant.message');
+    expect(assistantEvent).toBeDefined();
+    const msgContent = String(assistantEvent!.attributes['message.content']);
+    expect(msgContent.length).toBeLessThanOrEqual(10);
+  });
+
+  it('skips content events when sampler returns false', () => {
+    const fakeTracer = new FakeTracer();
+    jest.spyOn(trace, 'getTracer').mockReturnValue(fakeTracer as any);
+    const converter = new Eval2OtelConverter({
+      serviceName: 'svc',
+      captureContent: true,
+      contentSampler: () => false,
+    });
+    const evalResult: EvalResult = {
+      id: 'id2',
+      timestamp: Date.now(),
+      model: 'gpt-4',
+      system: 'openai',
+      operation: 'chat',
+      request: { model: 'gpt-4' },
+      response: { choices: [] },
+      usage: {},
+      performance: { duration: 1 },
+    } as any;
+    converter.convertEvalResult(evalResult);
+    const span = fakeTracer.lastSpan!;
+    expect(span.events.length).toBe(0);
+  });
+
+  it('applies per-field redaction hooks', () => {
+    const fakeTracer = new FakeTracer();
+    jest.spyOn(trace, 'getTracer').mockReturnValue(fakeTracer as any);
+    const converter = new Eval2OtelConverter({
+      serviceName: 'svc',
+      captureContent: true,
+      contentSampler: () => true,
+      redactMessageContent: (c, { role }) => (role === 'assistant' ? '[REDACTED]' : c),
+      redactToolArguments: () => '[ARGS]'.toString(),
+    });
+    const evalResult: EvalResult = {
+      id: 'id3',
+      timestamp: Date.now(),
+      model: 'gpt-4',
+      system: 'openai',
+      operation: 'chat',
+      request: { model: 'gpt-4' },
+      response: {
+        choices: [
+          {
+            index: 0,
+            finishReason: 'stop',
+            message: {
+              role: 'assistant',
+              content: 'SECRET',
+              toolCalls: [
+                {
+                  id: 'call1',
+                  type: 'function',
+                  function: { name: 'calc', arguments: { a: 1 } },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      usage: {},
+      performance: { duration: 1 },
+    } as any;
+    converter.convertEvalResult(evalResult);
+    const span = fakeTracer.lastSpan!;
+    const assistantEvent = span.events.find((e) => e.name === 'gen_ai.assistant.message');
+    expect(assistantEvent!.attributes['message.content']).toBe('[REDACTED]');
+    const toolEvent = span.events.find((e) => e.name === 'gen_ai.tool.message');
+    expect(toolEvent!.attributes['gen_ai.tool.arguments']).toBe('[ARGS]');
+  });
+});
+

--- a/test/converter-events.test.ts
+++ b/test/converter-events.test.ts
@@ -104,6 +104,32 @@ describe('Converter events', () => {
     expect(span.events.length).toBe(0);
   });
 
+  it('suppresses operational metadata when emitOperationalMetadata=false', () => {
+    const fakeTracer = new FakeTracer();
+    jest.spyOn(trace, 'getTracer').mockReturnValue(fakeTracer as any);
+    const converter = new Eval2OtelConverter({
+      serviceName: 'svc',
+      captureContent: true,
+      contentSampler: () => true,
+      emitOperationalMetadata: false,
+    });
+    const evalResult: EvalResult = {
+      id: 'id4',
+      timestamp: Date.now(),
+      model: 'gpt-4',
+      system: 'openai',
+      operation: 'chat',
+      request: { model: 'gpt-4' },
+      conversation: { id: 'c1', messages: [{ role: 'user', content: 'hi' }] },
+      response: { choices: [{ index: 0, finishReason: 'stop', message: { role: 'assistant', content: 'hey' } }] },
+      usage: {},
+      performance: { duration: 1 },
+    } as any;
+    converter.convertEvalResult(evalResult);
+    const span = fakeTracer.lastSpan!;
+    expect(span.events.length).toBe(0);
+  });
+
   it('applies per-field redaction hooks', () => {
     const fakeTracer = new FakeTracer();
     jest.spyOn(trace, 'getTracer').mockReturnValue(fakeTracer as any);
@@ -151,4 +177,3 @@ describe('Converter events', () => {
     expect(toolEvent!.attributes['gen_ai.tool.arguments']).toBe('[ARGS]');
   });
 });
-

--- a/test/metrics-branches.test.ts
+++ b/test/metrics-branches.test.ts
@@ -1,0 +1,66 @@
+import { metrics as otMetrics } from '@opentelemetry/api';
+import { Eval2OtelMetrics } from '../src/metrics';
+import { EvalResult } from '../src/types';
+
+describe('Metrics recording branches', () => {
+  class FakeHistogram {
+    public records: { value: number; attributes: Record<string, unknown> }[] = [];
+    record(value: number, attributes: Record<string, unknown>) {
+      this.records.push({ value, attributes });
+    }
+  }
+  class FakeMeter {
+    histograms = new Map<string, FakeHistogram>();
+    createHistogram(name: string) {
+      const h = new FakeHistogram();
+      this.histograms.set(name, h);
+      return h as any;
+    }
+    createCounter() {
+      return { add: jest.fn() } as any;
+    }
+  }
+
+  it('records token, timing, RAG, agent, and custom metrics', () => {
+    const fakeMeter = new FakeMeter();
+    jest.spyOn(otMetrics, 'getMeter').mockReturnValue(fakeMeter as any);
+
+    const evalMetrics = new Eval2OtelMetrics({ serviceName: 'svc' });
+    const evalResult: EvalResult = {
+      id: 'm1',
+      timestamp: Date.now(),
+      model: 'gpt-4',
+      system: 'openai',
+      operation: 'chat',
+      request: { model: 'gpt-4' },
+      response: {},
+      usage: { inputTokens: 3, outputTokens: 5 },
+      performance: { duration: 2, timeToFirstToken: 0.2, timePerOutputToken: 0.01 },
+      agent: { name: 'agent', steps: [{ name: 's1', status: 'completed', duration: 100 }] },
+      rag: {
+        documentsRetrieved: 2,
+        metrics: { contextPrecision: 0.8, contextRecall: 0.9, answerRelevance: 0.95, faithfulness: 0.9 },
+      },
+    } as any;
+
+    evalMetrics.recordMetrics(evalResult, { metrics: { accuracy: 0.9, latency: 1.2 } });
+
+    // Check some known histogram names got records
+    const names = Array.from(fakeMeter.histograms.keys());
+    expect(names).toEqual(expect.arrayContaining([
+      'gen_ai.client.token.usage',
+      'gen_ai.client.operation.duration',
+      'gen_ai.server.time_to_first_token',
+      'gen_ai.server.time_per_output_token',
+      'gen_ai.agent.step_duration',
+      'eval.accuracy',
+      'eval.latency',
+    ]));
+
+    const tokenHist = fakeMeter.histograms.get('gen_ai.client.token.usage')!;
+    expect(tokenHist.records.length).toBe(2);
+    const accHist = fakeMeter.histograms.get('eval.accuracy')!;
+    expect(accHist.records[0].value).toBe(0.9);
+  });
+});
+


### PR DESCRIPTION
Adds `emitOperationalMetadata` to `OtelConfig` to explicitly suppress conversation/choice/agent/RAG events even when content capture is enabled.\n\n- Converter gates content-driven events on this flag\n- Tests validate suppression behavior\n- README updated with new option\n\nDefaults to true to preserve existing behavior.