### PR TITLE
SDK: merge default Resource + OTLP protocol/headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,8 @@ interface OtelConfig {
   emitOperationalMetadata?: boolean; // Suppress conversation/choice/agent/RAG events when false (default true)
   redact?: (content: string) => string | null; // Custom redaction
   endpoint?: string;            // OpenTelemetry endpoint
+  exporterProtocol?: 'grpc' | 'http/protobuf' | 'http/json'; // OTLP protocol
+  exporterHeaders?: Record<string, string>; // OTLP headers (e.g., auth)
   resourceAttributes?: Record<string, string | number | boolean>;
 }
 ```

--- a/src/types.ts
+++ b/src/types.ts
@@ -177,6 +177,12 @@ export interface OtelConfig {
   /** OTLP endpoint */
   endpoint?: string;
   
+  /** OTLP exporter protocol (grpc | http/protobuf | http/json) */
+  exporterProtocol?: 'grpc' | 'http/protobuf' | 'http/json';
+  
+  /** OTLP exporter headers (e.g., authentication) */
+  exporterHeaders?: Record<string, string>;
+  
   /** Custom resource attributes */
   resourceAttributes?: Record<string, string | number | boolean>;
 }

--- a/test/sdk-init.test.ts
+++ b/test/sdk-init.test.ts
@@ -1,0 +1,31 @@
+import { NodeSDK } from '@opentelemetry/sdk-node';
+import * as sdkNode from '@opentelemetry/sdk-node';
+import { createEval2Otel } from '../src/index';
+
+jest.mock('@opentelemetry/sdk-node');
+
+describe('SDK initialization', () => {
+  it('sets OTLP env based on config and merges default resource', () => {
+    const startMock = jest.fn();
+    // @ts-ignore mock constructor
+    (sdkNode as any).NodeSDK.mockImplementation((cfg: any) => {
+      // Ensure resource exists and has merge result
+      expect(cfg.resource).toBeDefined();
+      return { start: startMock };
+    });
+
+    const eval2otel = createEval2Otel({
+      serviceName: 'svc',
+      endpoint: 'http://collector:4318',
+      exporterProtocol: 'http/protobuf',
+      exporterHeaders: { Authorization: 'Bearer token' },
+    });
+    expect(process.env.OTEL_EXPORTER_OTLP_ENDPOINT).toBe('http://collector:4318');
+    expect(process.env.OTEL_EXPORTER_OTLP_PROTOCOL).toBe('http/protobuf');
+    expect(process.env.OTEL_EXPORTER_OTLP_HEADERS).toContain('Authorization=Bearer token');
+
+    // Start gets called during createEval2Otel.initialize()
+    expect(startMock).toHaveBeenCalled();
+  });
+});
+


### PR DESCRIPTION
Improve SDK initialization:\n\n- Merge `Resource.default()` with custom resource attributes\n- Add `exporterProtocol` and `exporterHeaders` to configure OTLP exporter via env vars\n- Add tests for env var setup and resource construction\n- Update README config interface\n\nBackward compatible; defaults preserved.