### PR TITLE
Add optional content_truncated flag for messages

### DIFF
--- a/src/converter.ts
+++ b/src/converter.ts
@@ -323,10 +323,17 @@ export class Eval2OtelConverter {
         const contentStr = typeof message.content === 'string' 
           ? message.content 
           : JSON.stringify(message.content);
-        
         const redactedContent = this.redactMessageContent(contentStr, message.role);
         if (redactedContent !== null) {
-          attributes['gen_ai.message.content'] = redactedContent;
+          const max = this.config.contentMaxLength;
+          if (typeof max === 'number' && max > 0 && redactedContent.length > max) {
+            attributes['gen_ai.message.content'] = redactedContent.slice(0, max);
+            if (this.config.markTruncatedContent) {
+              attributes['gen_ai.message.content_truncated'] = true;
+            }
+          } else {
+            attributes['gen_ai.message.content'] = redactedContent;
+          }
         }
       }
 
@@ -356,10 +363,17 @@ export class Eval2OtelConverter {
         const contentStr = typeof choice.message.content === 'string'
           ? choice.message.content
           : JSON.stringify(choice.message.content);
-        
         const redactedContent = this.redactMessageContent(contentStr, choice.message.role);
         if (redactedContent !== null) {
-          attributes['gen_ai.message.content'] = this.truncateContent(redactedContent);
+          const max = this.config.contentMaxLength;
+          if (typeof max === 'number' && max > 0 && redactedContent.length > max) {
+            attributes['gen_ai.message.content'] = redactedContent.slice(0, max);
+            if (this.config.markTruncatedContent) {
+              attributes['gen_ai.message.content_truncated'] = true;
+            }
+          } else {
+            attributes['gen_ai.message.content'] = redactedContent;
+          }
         }
       }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -164,6 +164,9 @@ export interface OtelConfig {
 
   /** Whether to emit operational metadata events (conversation, choices, agent, RAG). Default: true */
   emitOperationalMetadata?: boolean;
+
+  /** When true, add gen_ai.message.content_truncated=true when message content is truncated */
+  markTruncatedContent?: boolean;
   
   /** Redaction function for sensitive content */
   redact?: (content: string) => string | null;

--- a/test/converter-events.test.ts
+++ b/test/converter-events.test.ts
@@ -28,6 +28,7 @@ describe('Converter events', () => {
       serviceName: 'svc',
       captureContent: true,
       contentMaxLength: 10,
+      markTruncatedContent: true,
       contentSampler: () => true,
     });
 
@@ -78,6 +79,7 @@ describe('Converter events', () => {
     expect(assistantEvent).toBeDefined();
     const msgContent = String(assistantEvent!.attributes['gen_ai.message.content']);
     expect(msgContent.length).toBeLessThanOrEqual(10);
+    expect(assistantEvent!.attributes['gen_ai.message.content_truncated']).toBe(true);
   });
 
   it('skips content events when sampler returns false', () => {


### PR DESCRIPTION
Adds `markTruncatedContent` to `OtelConfig` and sets `gen_ai.message.content_truncated=true` when captured message content is truncated due to `contentMaxLength`.\n\n- Applies to conversation and assistant messages\n- Tests updated to assert flag when configured\n\nDefault is off; enabling the flag preserves current behavior unless truncation occurs.