### PR TITLE
SDK: Signal-specific OTLP endpoints and headers

### DIFF
--- a/src/attributes.ts
+++ b/src/attributes.ts
@@ -1,0 +1,20 @@
+// Centralized attribute keys to avoid typos and ease refactors
+export const ATTR = {
+  // Message-level
+  MESSAGE_CONTENT: 'gen_ai.message.content',
+  MESSAGE_ROLE: 'gen_ai.message.role',
+  MESSAGE_INDEX: 'gen_ai.message.index',
+  MESSAGE_CONTENT_TRUNCATED: 'gen_ai.message.content_truncated',
+
+  // Choice-level
+  RESPONSE_CHOICE_INDEX: 'gen_ai.response.choice.index',
+  RESPONSE_FINISH_REASON: 'gen_ai.response.finish_reason',
+
+  // Tooling
+  TOOL_NAME: 'gen_ai.tool.name',
+  TOOL_CALL_ID: 'gen_ai.tool.call.id',
+  TOOL_ARGUMENTS: 'gen_ai.tool.arguments',
+} as const;
+
+export type AttrKeys = typeof ATTR[keyof typeof ATTR];
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,6 +69,32 @@ export class Eval2Otel {
         .join(',');
     }
 
+    // Signal-specific overrides
+    if (this.config.tracesEndpoint) {
+      process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = this.config.tracesEndpoint;
+    }
+    if (this.config.metricsEndpoint) {
+      process.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT = this.config.metricsEndpoint;
+    }
+    if (this.config.logsEndpoint) {
+      process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT = this.config.logsEndpoint;
+    }
+    if (this.config.tracesHeaders && Object.keys(this.config.tracesHeaders).length > 0) {
+      process.env.OTEL_EXPORTER_OTLP_TRACES_HEADERS = Object.entries(this.config.tracesHeaders)
+        .map(([k, v]) => `${k}=${String(v)}`)
+        .join(',');
+    }
+    if (this.config.metricsHeaders && Object.keys(this.config.metricsHeaders).length > 0) {
+      process.env.OTEL_EXPORTER_OTLP_METRICS_HEADERS = Object.entries(this.config.metricsHeaders)
+        .map(([k, v]) => `${k}=${String(v)}`)
+        .join(',');
+    }
+    if (this.config.logsHeaders && Object.keys(this.config.logsHeaders).length > 0) {
+      process.env.OTEL_EXPORTER_OTLP_LOGS_HEADERS = Object.entries(this.config.logsHeaders)
+        .map(([k, v]) => `${k}=${String(v)}`)
+        .join(',');
+    }
+
     this.sdk = new NodeSDK(sdkConfig);
     this.sdk.start();
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -185,6 +185,16 @@ export interface OtelConfig {
   
   /** OTLP exporter headers (e.g., authentication) */
   exporterHeaders?: Record<string, string>;
+
+  /** Signal-specific endpoints (override global endpoint if provided) */
+  tracesEndpoint?: string;
+  metricsEndpoint?: string;
+  logsEndpoint?: string;
+
+  /** Signal-specific headers (override global headers if provided) */
+  tracesHeaders?: Record<string, string>;
+  metricsHeaders?: Record<string, string>;
+  logsHeaders?: Record<string, string>;
   
   /** Custom resource attributes */
   resourceAttributes?: Record<string, string | number | boolean>;

--- a/test/sdk-init.test.ts
+++ b/test/sdk-init.test.ts
@@ -27,5 +27,29 @@ describe('SDK initialization', () => {
     // Start gets called during createEval2Otel.initialize()
     expect(startMock).toHaveBeenCalled();
   });
-});
 
+  it('sets signal-specific endpoints and headers when provided', () => {
+    const startMock = jest.fn();
+    // @ts-ignore mock constructor
+    (sdkNode as any).NodeSDK.mockImplementation(() => ({ start: startMock }));
+
+    const eval2otel = createEval2Otel({
+      serviceName: 'svc',
+      endpoint: 'http://collector:4318',
+      tracesEndpoint: 'http://collector:4318/v1/traces',
+      metricsEndpoint: 'http://collector:4318/v1/metrics',
+      logsEndpoint: 'http://collector:4318/v1/logs',
+      tracesHeaders: { 'x-trace': 't' },
+      metricsHeaders: { 'x-metric': 'm' },
+      logsHeaders: { 'x-log': 'l' },
+    });
+
+    expect(process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT).toBe('http://collector:4318/v1/traces');
+    expect(process.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT).toBe('http://collector:4318/v1/metrics');
+    expect(process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT).toBe('http://collector:4318/v1/logs');
+    expect(process.env.OTEL_EXPORTER_OTLP_TRACES_HEADERS).toContain('x-trace=t');
+    expect(process.env.OTEL_EXPORTER_OTLP_METRICS_HEADERS).toContain('x-metric=m');
+    expect(process.env.OTEL_EXPORTER_OTLP_LOGS_HEADERS).toContain('x-log=l');
+    expect(startMock).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Add support for per-signal exporter configuration via env vars:\n\n- tracesEndpoint/metricsEndpoint/logsEndpoint\n- tracesHeaders/metricsHeaders/logsHeaders\n\nFalls back to global endpoint/headers when per-signal not provided. Includes unit tests. Lint/tests/build pass.