### PR TITLE
CI: add optional E2E workflow + privacy docs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,35 @@
+name: E2E (optional)
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * *' # daily @ 06:00 UTC
+  push:
+    branches: [ main ]
+
+jobs:
+  e2e:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Run E2E test-harness
+        env:
+          OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf
+        run: |
+          bash test-harness/run-tests.sh
+

--- a/README.md
+++ b/README.md
@@ -372,6 +372,21 @@ const eval2otel = createEval2Otel({
 });
 ```
 
+### Additional Privacy Controls
+
+```typescript
+const eval2otel = createEval2Otel({
+  serviceName: 'my-service',
+  captureContent: true,           // opt-in
+  emitOperationalMetadata: false, // suppress conversation/choice/agent/RAG events
+  contentMaxLength: 4096,         // truncate captured content
+  markTruncatedContent: true,     // add gen_ai.message.content_truncated when applied
+  contentSampler: (evalResult) => evalResult.operation !== 'embeddings', // custom sampler
+  redactMessageContent: (content, { role }) => role === 'assistant' ? '[REDACTED]' : content,
+  redactToolArguments: (args, { functionName }) => functionName === 'sensitive' ? '{}' : args,
+});
+```
+
 ## Backend Integration
 
 eval2otel works with any OpenTelemetry-compatible backend. See [Backend Integration Guide](./docs/backends.md) for specific setup instructions for:


### PR DESCRIPTION
- Add optional E2E GitHub Action (workflow_dispatch + daily + on main) using test-harness/run-tests.sh\n- Update README with privacy flags usage: emitOperationalMetadata, contentMaxLength, markTruncatedContent, contentSampler, redactMessageContent, redactToolArguments\n\nLint/tests/build pass.