### PR TITLE
ci: set retention on uploaded workflow artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
         with:
+          retention-days: 14
           name: coverage-${{ matrix.node-version }}
           path: |
             coverage/lcov.info


### PR DESCRIPTION
## Summary
- set explicit retention on GitHub Actions upload-artifact steps
- keep CI/release diagnostic artifacts from falling back to repo defaults

## Test plan
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f) }' <changed workflows>
- git diff --check
