### PR TITLE
[codex] Add eval2otel conformance evidence contract

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -29,8 +33,17 @@ jobs:
       
       - name: Test
         run: npm test
+
+      - name: Package smoke
+        run: |
+          npm pack --dry-run
+          npm pack
+          package_file="$(ls eval2otel-*.tgz | head -n1)"
+          mkdir /tmp/eval2otel-smoke
+          npm install --prefix /tmp/eval2otel-smoke "$package_file"
+          node -e "const pkg = require('/tmp/eval2otel-smoke/node_modules/eval2otel'); if (!pkg.createEval2Otel || !pkg.EVAL2OTEL_CONTRACT_VERSION) process.exit(1)"
       
       - name: Publish to NPM
-        run: npm publish
+        run: npm publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Added
+- Versioned `eval2otel.v1` telemetry contract documentation and fixture-backed conformance tests.
+- Optional `EvalResult.provenance` and `EvalResult.evidence` metadata for audit joins, payload hashes, adapter identity, run/case/dataset identity, and conversion warnings.
+- Eval2Otel self-telemetry for conversion attempts, duration, warning count, dropped events, redacted content, and truncated content.
+- Provider conversion helper that returns structured evidence and warnings alongside the converted `EvalResult`.
+
+### Changed
+- Emit Eval2Otel contract/evidence attributes on spans, including redaction, truncation, warning, and dropped-event counters.
+- Harden npm publishing with package smoke validation and provenance publishing.
+
 ## [0.3.0] - 2025-08-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -213,11 +213,13 @@ const ragEval: EvalResult = {
 ## Telemetry Model
 
 ### Spans
-The library creates spans following the `{operation} {model}` naming convention with these attributes:
+The library creates operation-centric spans such as `gen_ai.chat`, `gen_ai.embeddings`, and `gen_ai.execute_tool` with these attributes:
 
 - `gen_ai.operation.name`: The operation type (chat, embeddings, execute_tool)
 - `gen_ai.system`: The AI system (openai, anthropic, etc.)
 - `gen_ai.provider.name`: Provider discriminator (`openai`, `anthropic`, `aws.bedrock`, `azure.openai`, `google.vertex`, `ollama`)
+- `evalops.contract.version`: Eval2Otel telemetry contract version
+- `evalops.eval.id`: Stable evaluation identifier
 - `gen_ai.request.model`: Model name
 - `gen_ai.request.temperature`: Temperature setting
 - `gen_ai.usage.input_tokens`: Input token count
@@ -245,9 +247,45 @@ Automatically recorded metrics include:
 - `gen_ai.client.operation.duration`: Operation duration
 - `gen_ai.server.time_to_first_token`: Time to first token
 - `gen_ai.server.time_per_output_token`: Time per output token
+- `eval2otel.conversion.count`: Eval2Otel conversion attempts by status
+- `eval2otel.conversion.warning_count`: Conversion warnings for SLO gates
+- `eval2otel.conversion.dropped_event_count`: Operational events dropped by caps
+- `eval2otel.conversion.redacted_content_count`: Content fields redacted during conversion
 - Custom evaluation metrics (accuracy, BLEU, etc.)
 
 Streaming support: record TTFT and inter-token timings when provided (client or server streaming).
+
+### Contract, Provenance, And Evidence
+
+Eval2Otel publishes a versioned telemetry contract in [docs/contract/eval2otel-v1.md](./docs/contract/eval2otel-v1.md). The contract is backed by golden fixtures in `test/fixtures/conformance` so provider and framework adapters cannot drift silently.
+
+`EvalResult` accepts optional `provenance` and `evidence` metadata for audit joins:
+
+```typescript
+const evalResult: EvalResult = {
+  id: 'case-123',
+  timestamp: Date.now(),
+  model: 'gpt-4o-mini',
+  system: 'openai',
+  operation: 'chat',
+  request: { model: 'gpt-4o-mini' },
+  response: {},
+  usage: {},
+  performance: { duration: 0.8 },
+  provenance: {
+    sourceFramework: 'promptfoo',
+    runId: 'run-2026-05-18',
+    caseId: 'case-123',
+    datasetId: 'evalops-core',
+    datasetVersion: '2026.05',
+  },
+  evidence: {
+    rawPayloadSha256: '...',
+    promptSha256: '...',
+    responseSha256: '...',
+  },
+};
+```
 
 ## Configuration
 

--- a/docs/contract/eval2otel-v1.md
+++ b/docs/contract/eval2otel-v1.md
@@ -1,0 +1,93 @@
+# Eval2Otel V1 Telemetry Contract
+
+`eval2otel.v1` is the public compatibility contract for converting AI evaluation
+results into OpenTelemetry GenAI telemetry. New providers and framework adapters
+must preserve this shape unless they introduce a new contract version.
+
+## Required Span Shape
+
+Every converted evaluation creates one client span named by operation:
+
+| Eval operation | Span name |
+| --- | --- |
+| `chat`, `text_completion` | `gen_ai.chat` |
+| `embeddings` | `gen_ai.embeddings` |
+| `execute_tool` | `gen_ai.execute_tool` |
+| `agent_execution` | `gen_ai.agent` |
+| `workflow_step` | `gen_ai.workflow` |
+
+Every span must include:
+
+- `gen_ai.operation.name`
+- `gen_ai.system`
+- `evalops.contract.version`
+- `evalops.semconv.version`
+- `evalops.eval.id`
+- `evalops.warning_count`
+- `evalops.dropped_event_count`
+- `evalops.redacted_content_count`
+- `evalops.truncated_content_count`
+
+Provider-aware conversions should include `gen_ai.provider.name` using the
+normalized provider names exported by `normalizeProviderName`.
+
+## Provenance And Evidence
+
+The optional `EvalResult.provenance` and `EvalResult.evidence` fields are for
+audit metadata, not prompt text. When present, they are emitted as namespaced
+attributes:
+
+- `evalops.source.framework`
+- `evalops.run.id`
+- `evalops.case.id`
+- `evalops.dataset.id`
+- `evalops.dataset.version`
+- `evalops.adapter.name`
+- `evalops.adapter.version`
+- `evalops.raw_payload_sha256`
+- `evalops.prompt_sha256`
+- `evalops.response_sha256`
+
+Adapters should hash raw provider/framework payloads before emitting them. The
+hash gives operators a stable join key without copying customer content into
+normal telemetry.
+
+## Privacy Guardrails
+
+Content capture remains opt-in through `captureContent`. When content capture is
+enabled:
+
+- redacted or changed content increments `evalops.redacted_content_count`;
+- truncated message or tool content increments `evalops.truncated_content_count`;
+- content redacted to `null` is replaced by `evalops.content_sha256`;
+- event caps increment `evalops.dropped_event_count`.
+
+These counters are part of the contract so dashboards and CI can detect privacy
+or cardinality regressions.
+
+## Operational Telemetry
+
+`Eval2Otel.processEvaluation` records eval2otel self-telemetry:
+
+- `eval2otel.conversion.count`
+- `eval2otel.conversion.duration`
+- `eval2otel.conversion.warning_count`
+- `eval2otel.conversion.dropped_event_count`
+- `eval2otel.conversion.redacted_content_count`
+- `eval2otel.conversion.truncated_content_count`
+
+Consumers can use these metrics as SLO gates for adapter quality and privacy
+behavior.
+
+## Conformance Fixtures
+
+The fixture suite in `test/fixtures/conformance` is the executable form of this
+contract. Each fixture asserts:
+
+- span name;
+- contract, semantic convention, provider, and provenance attributes;
+- emitted event order and event attributes;
+- redaction, truncation, warning, and dropped-event counters.
+
+Any adapter or converter change that alters these outputs must update this
+document and fixture expectations in the same pull request.

--- a/src/attributes.ts
+++ b/src/attributes.ts
@@ -20,6 +20,25 @@ export const ATTR = {
   // Provider
   PROVIDER_NAME: 'gen_ai.provider.name',
 
+  // Eval2Otel contract/evidence attributes
+  CONTRACT_VERSION: 'evalops.contract.version',
+  SEMCONV_VERSION: 'evalops.semconv.version',
+  EVAL_ID: 'evalops.eval.id',
+  SOURCE_FRAMEWORK: 'evalops.source.framework',
+  RUN_ID: 'evalops.run.id',
+  CASE_ID: 'evalops.case.id',
+  DATASET_ID: 'evalops.dataset.id',
+  DATASET_VERSION: 'evalops.dataset.version',
+  ADAPTER_NAME: 'evalops.adapter.name',
+  ADAPTER_VERSION: 'evalops.adapter.version',
+  RAW_PAYLOAD_SHA256: 'evalops.raw_payload_sha256',
+  PROMPT_SHA256: 'evalops.prompt_sha256',
+  RESPONSE_SHA256: 'evalops.response_sha256',
+  WARNING_COUNT: 'evalops.warning_count',
+  DROPPED_EVENT_COUNT: 'evalops.dropped_event_count',
+  REDACTED_CONTENT_COUNT: 'evalops.redacted_content_count',
+  TRUNCATED_CONTENT_COUNT: 'evalops.truncated_content_count',
+
   // Privacy helpers
   CONTENT_SHA256: 'evalops.content_sha256',
 } as const;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,7 @@
  * Usage: npx eval2otel-cli ingest --file ./evals.jsonl [--provider <mode>]
  */
 import { createEval2Otel, EvalResult, OtelConfig } from './index';
-import { detectProvider, convertProviderToEvalResult } from './helpers';
+import { convertProviderWithEvidence, detectProvider } from './helpers';
 import * as fs from 'fs';
 import * as readline from 'readline';
 
@@ -73,7 +73,14 @@ export async function runCli(argv: string[]) {
         if (providerMode && !['openai-chat','openai-compatible','anthropic','cohere','bedrock','vertex','ollama'].includes(mode)) {
           throw new Error(`Unknown --provider value: ${providerMode}`);
         }
-        evalResult = convertProviderToEvalResult(request, response, start, end, mode as any);
+        const conversion = convertProviderWithEvidence({
+          request,
+          response,
+          startTime: start,
+          endTime: end,
+          provider: mode as any,
+        });
+        evalResult = conversion.evalResult;
         if (!evalResult) {
           if (!providerMode && detected === 'unknown' && noFallback) {
             throw new Error('Autodetect failed and fallback disabled');

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -1,0 +1,170 @@
+import { createHash } from 'crypto';
+import { ATTR } from './attributes';
+import {
+  ConversionReport,
+  ConversionWarning,
+  Eval2OtelEvidence,
+  EvalResult,
+  OtelConfig,
+} from './types';
+
+export const EVAL2OTEL_CONTRACT_VERSION = 'eval2otel.v1';
+export const UNKNOWN_SEMCONV_VERSION = 'unspecified';
+
+export interface ConversionCounters {
+  eventCount?: number;
+  droppedEventCount?: number;
+  redactedContentCount?: number;
+  truncatedContentCount?: number;
+  durationMs?: number;
+}
+
+export function sha256(value: unknown): string {
+  const encoded = typeof value === 'string' ? value : JSON.stringify(value);
+  return createHash('sha256').update(encoded ?? '').digest('hex');
+}
+
+export function normalizeProviderName(system?: string): string | undefined {
+  if (!system) return undefined;
+  const s = system.toLowerCase();
+  if (s.includes('azure')) return 'azure.openai';
+  if (s.includes('bedrock') || s.includes('aws')) return 'aws.bedrock';
+  if (s.includes('vertex') || s.includes('gemini') || s.includes('google')) return 'google.vertex';
+  if (s.includes('anthropic') || s.includes('claude')) return 'anthropic';
+  if (s.includes('openai')) return 'openai';
+  return s;
+}
+
+export function resolveSemconvVersion(config: OtelConfig, evalResult?: EvalResult): string {
+  return evalResult?.provenance?.semconvVersion
+    ?? config.semconvGaVersion
+    ?? config.semconvStabilityOptIn
+    ?? UNKNOWN_SEMCONV_VERSION;
+}
+
+export function collectConversionWarnings(evalResult: EvalResult): ConversionWarning[] {
+  return evalResult.evidence?.warnings ?? [];
+}
+
+export function buildEval2OtelEvidence(
+  evalResult: EvalResult,
+  counters: ConversionCounters = {},
+): Eval2OtelEvidence {
+  const warnings = collectConversionWarnings(evalResult);
+  return {
+    rawPayloadSha256: evalResult.evidence?.rawPayloadSha256,
+    promptSha256: evalResult.evidence?.promptSha256 ?? hashPrompt(evalResult),
+    responseSha256: evalResult.evidence?.responseSha256 ?? hashResponse(evalResult),
+    redactedContentCount: counters.redactedContentCount ?? evalResult.evidence?.redactedContentCount ?? 0,
+    truncatedContentCount: counters.truncatedContentCount ?? evalResult.evidence?.truncatedContentCount ?? 0,
+    droppedEventCount: counters.droppedEventCount ?? evalResult.evidence?.droppedEventCount ?? 0,
+    warningCount: counters.eventCount === undefined
+      ? (evalResult.evidence?.warningCount ?? warnings.length)
+      : (evalResult.evidence?.warningCount ?? warnings.length),
+    warnings,
+  };
+}
+
+export function buildEval2OtelAttributes(
+  evalResult: EvalResult,
+  config: OtelConfig,
+  counters: ConversionCounters = {},
+): Record<string, string | number | boolean | string[]> {
+  const evidence = buildEval2OtelEvidence(evalResult, counters);
+  const provenance = evalResult.provenance;
+  const attrs: Record<string, string | number | boolean | string[]> = {
+    [ATTR.CONTRACT_VERSION]: provenance?.contractVersion ?? EVAL2OTEL_CONTRACT_VERSION,
+    [ATTR.SEMCONV_VERSION]: resolveSemconvVersion(config, evalResult),
+    [ATTR.EVAL_ID]: evalResult.id,
+    [ATTR.WARNING_COUNT]: evidence.warningCount ?? 0,
+    [ATTR.DROPPED_EVENT_COUNT]: evidence.droppedEventCount ?? 0,
+    [ATTR.REDACTED_CONTENT_COUNT]: evidence.redactedContentCount ?? 0,
+    [ATTR.TRUNCATED_CONTENT_COUNT]: evidence.truncatedContentCount ?? 0,
+  };
+
+  addString(attrs, ATTR.SOURCE_FRAMEWORK, provenance?.sourceFramework);
+  addString(attrs, ATTR.RUN_ID, provenance?.runId);
+  addString(attrs, ATTR.CASE_ID, provenance?.caseId);
+  addString(attrs, ATTR.DATASET_ID, provenance?.datasetId);
+  addString(attrs, ATTR.DATASET_VERSION, provenance?.datasetVersion);
+  addString(attrs, ATTR.ADAPTER_NAME, provenance?.adapter);
+  addString(attrs, ATTR.ADAPTER_VERSION, provenance?.adapterVersion);
+  addString(attrs, ATTR.RAW_PAYLOAD_SHA256, evidence.rawPayloadSha256);
+  addString(attrs, ATTR.PROMPT_SHA256, evidence.promptSha256);
+  addString(attrs, ATTR.RESPONSE_SHA256, evidence.responseSha256);
+
+  return attrs;
+}
+
+export function buildConversionReport(
+  evalResult: EvalResult,
+  config: OtelConfig,
+  spanName: string,
+  counters: ConversionCounters = {},
+): ConversionReport {
+  const evidence = buildEval2OtelEvidence(evalResult, counters);
+  const warnings = collectConversionWarnings(evalResult);
+  return {
+    evalId: evalResult.id,
+    success: true,
+    contractVersion: evalResult.provenance?.contractVersion ?? EVAL2OTEL_CONTRACT_VERSION,
+    semconvVersion: resolveSemconvVersion(config, evalResult),
+    spanName,
+    eventCount: counters.eventCount ?? 0,
+    droppedEventCount: evidence.droppedEventCount ?? 0,
+    redactedContentCount: evidence.redactedContentCount ?? 0,
+    truncatedContentCount: evidence.truncatedContentCount ?? 0,
+    warningCount: evidence.warningCount ?? warnings.length,
+    warnings,
+    durationMs: counters.durationMs ?? 0,
+  };
+}
+
+export function buildFailureConversionReport(
+  evalResult: Partial<EvalResult> | undefined,
+  config: OtelConfig,
+  error: unknown,
+  durationMs: number,
+): ConversionReport {
+  const errorType = error instanceof Error ? error.name : typeof error;
+  return {
+    evalId: evalResult?.id ?? 'unknown',
+    success: false,
+    contractVersion: evalResult?.provenance?.contractVersion ?? EVAL2OTEL_CONTRACT_VERSION,
+    semconvVersion: evalResult ? resolveSemconvVersion(config, evalResult as EvalResult) : UNKNOWN_SEMCONV_VERSION,
+    eventCount: 0,
+    droppedEventCount: 0,
+    redactedContentCount: 0,
+    truncatedContentCount: 0,
+    warningCount: 1,
+    warnings: [{
+      code: 'conversion.failed',
+      message: error instanceof Error ? error.message : String(error),
+      severity: 'error',
+    }],
+    durationMs,
+    errorType,
+  };
+}
+
+function hashPrompt(evalResult: EvalResult): string | undefined {
+  if (!evalResult.conversation?.messages?.length) return undefined;
+  return sha256(evalResult.conversation.messages.map(message => ({
+    role: message.role,
+    content: message.content,
+    toolCallId: message.toolCallId,
+  })));
+}
+
+function hashResponse(evalResult: EvalResult): string | undefined {
+  if (!evalResult.response) return undefined;
+  return sha256(evalResult.response);
+}
+
+function addString(
+  attrs: Record<string, string | number | boolean | string[]>,
+  key: string,
+  value: string | undefined,
+): void {
+  if (value) attrs[key] = value;
+}

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -1,12 +1,20 @@
 import { SpanKind, SpanStatusCode, trace, Span, context } from '@opentelemetry/api';
 import { createHash } from 'crypto';
-import { EvalResult, GenAIAttributes, OtelConfig, ProcessOptions, EvalResultSchema } from './types';
+import { ConversionReport, EvalResult, GenAIAttributes, OtelConfig, ProcessOptions, EvalResultSchema } from './types';
 import { ATTR } from './attributes';
+import {
+  buildConversionReport,
+  buildEval2OtelAttributes,
+  normalizeProviderName,
+} from './contract';
 
 export class Eval2OtelConverter {
   private tracer;
   private config: OtelConfig;
   private eventCounts: WeakMap<Span, number> = new WeakMap();
+  private droppedEventCounts: WeakMap<Span, number> = new WeakMap();
+  private redactedContentCounts: WeakMap<Span, number> = new WeakMap();
+  private truncatedContentCounts: WeakMap<Span, number> = new WeakMap();
 
   constructor(config: OtelConfig) {
     this.config = config;
@@ -16,7 +24,8 @@ export class Eval2OtelConverter {
   /**
    * Convert an evaluation result to OpenTelemetry span and events
    */
-  convertEvalResult(evalResult: EvalResult, options?: ProcessOptions): void {
+  convertEvalResult(evalResult: EvalResult, options?: ProcessOptions): ConversionReport {
+    const conversionStartedAt = Date.now();
     // Validate input
     const validated = EvalResultSchema.parse(evalResult);
     
@@ -89,7 +98,17 @@ export class Eval2OtelConverter {
       this.addRAGChunkEvents(span, validated);
     }
 
+    const counters = {
+      eventCount: this.eventCounts.get(span) ?? 0,
+      droppedEventCount: this.droppedEventCounts.get(span) ?? 0,
+      redactedContentCount: this.redactedContentCounts.get(span) ?? 0,
+      truncatedContentCount: this.truncatedContentCounts.get(span) ?? 0,
+      durationMs: Date.now() - conversionStartedAt,
+    };
+    this.setSpanAttributes(span, buildEval2OtelAttributes(validated, this.config, counters));
+    const report = buildConversionReport(validated, this.config, spanName, counters);
     span.end(endTime);
+    return report;
   }
 
   /**
@@ -160,9 +179,10 @@ export class Eval2OtelConverter {
   /**
    * Truncate content if a max length is configured
    */
-  private truncateContent(content: string): string {
+  private truncateContent(content: string, span?: Span): string {
     const max = this.config.contentMaxLength;
     if (typeof max === 'number' && max > 0 && content.length > max) {
+      if (span) this.trackTruncation(span, true);
       return content.slice(0, max);
     }
     return content;
@@ -173,12 +193,48 @@ export class Eval2OtelConverter {
   }
 
   private canAddEvent(span: Span): boolean {
-    const cap = this.config.maxEventsPerSpan;
-    if (!cap || cap <= 0) return true;
     const current = this.eventCounts.get(span) ?? 0;
-    if (current >= cap) return false;
+    const cap = this.config.maxEventsPerSpan;
+    if (!cap || cap <= 0) {
+      this.eventCounts.set(span, current + 1);
+      return true;
+    }
+    if (current >= cap) {
+      this.incrementWeakCounter(this.droppedEventCounts, span);
+      return false;
+    }
     this.eventCounts.set(span, current + 1);
     return true;
+  }
+
+  private trackRedaction(span: Span, original: string, redacted: string | null): string | null {
+    if (redacted === null || redacted !== original) {
+      this.incrementWeakCounter(this.redactedContentCounts, span);
+    }
+    return redacted;
+  }
+
+  private trackTruncation(span: Span, truncated: boolean): void {
+    if (truncated) {
+      this.incrementWeakCounter(this.truncatedContentCounts, span);
+    }
+  }
+
+  private incrementWeakCounter(map: WeakMap<Span, number>, span: Span): void {
+    map.set(span, (map.get(span) ?? 0) + 1);
+  }
+
+  private setSpanAttributes(span: Span, attrs: Record<string, string | number | boolean | string[]>): void {
+    if (typeof (span as unknown as { setAttributes?: unknown }).setAttributes === 'function') {
+      (span as unknown as { setAttributes: (attributes: Record<string, string | number | boolean | string[]>) => void })
+        .setAttributes(attrs);
+      return;
+    }
+    Object.entries(attrs).forEach(([key, value]) => {
+      if (typeof span.setAttribute === 'function') {
+        span.setAttribute(key, value);
+      }
+    });
   }
 
   /**
@@ -191,10 +247,11 @@ export class Eval2OtelConverter {
     const attributes: GenAIAttributes = {
       'gen_ai.operation.name': evalResult.operation,
       'gen_ai.system': evalResult.system ?? 'unknown',
+      ...buildEval2OtelAttributes(evalResult, this.config),
     };
 
     // Provider discriminator aligned with latest GenAI semconv
-    const provider = this.getProviderName(evalResult.system);
+    const provider = normalizeProviderName(evalResult.system);
     if (provider) {
       (attributes as any)[ATTR.PROVIDER_NAME] = provider;
     }
@@ -352,21 +409,6 @@ export class Eval2OtelConverter {
   }
 
   /**
-   * Normalize provider names for gen_ai.provider.name
-   */
-  private getProviderName(system?: string): string | undefined {
-    if (!system) return undefined;
-    const s = system.toLowerCase();
-    if (s.includes('azure')) return 'azure.openai';
-    if (s.includes('bedrock') || s.includes('aws')) return 'aws.bedrock';
-    if (s.includes('vertex') || s.includes('gemini') || s.includes('google')) return 'google.vertex';
-    if (s.includes('anthropic') || s.includes('claude')) return 'anthropic';
-    if (s.includes('openai')) return 'openai';
-    // Keep explicit systems such as "ollama" or custom identifiers
-    return s;
-  }
-
-  /**
    * Add conversation message events to span
    */
   private addConversationEvents(span: Span, evalResult: EvalResult): void {
@@ -376,7 +418,7 @@ export class Eval2OtelConverter {
       const eventName = `gen_ai.${message.role}.message`;
       const attributes: Record<string, string | number | boolean> = {
         'gen_ai.system': evalResult.system ?? 'unknown',
-        [ATTR.PROVIDER_NAME]: this.getProviderName(evalResult.system) ?? 'unknown',
+        [ATTR.PROVIDER_NAME]: normalizeProviderName(evalResult.system) ?? 'unknown',
         [ATTR.MESSAGE_ROLE]: message.role,
         [ATTR.MESSAGE_INDEX]: index,
       };
@@ -384,7 +426,7 @@ export class Eval2OtelConverter {
       if (message.content !== undefined) {
         if (typeof message.content === 'string') {
           const original = message.content;
-          const redacted = this.redactMessageContent(original, message.role);
+          const redacted = this.trackRedaction(span, original, this.redactMessageContent(original, message.role));
           if (redacted !== null) {
             const max = this.config.contentMaxLength;
             let val = redacted;
@@ -393,6 +435,7 @@ export class Eval2OtelConverter {
               val = redacted.slice(0, max);
               truncated = true;
             }
+            this.trackTruncation(span, truncated);
             attributes[ATTR.MESSAGE_CONTENT] = val;
             attributes[ATTR.MESSAGE_CONTENT_TYPE] = 'text';
             if (truncated && this.config.markTruncatedContent) {
@@ -405,7 +448,7 @@ export class Eval2OtelConverter {
         } else {
           // Structured JSON-like content
           const jsonStr = JSON.stringify(message.content);
-          const redacted = this.redactMessageContent(jsonStr, message.role);
+          const redacted = this.trackRedaction(span, jsonStr, this.redactMessageContent(jsonStr, message.role));
           if (redacted !== null) {
             const max = this.config.contentMaxLength;
             let val = redacted;
@@ -414,6 +457,7 @@ export class Eval2OtelConverter {
               val = redacted.slice(0, max);
               truncated = true;
             }
+            this.trackTruncation(span, truncated);
             attributes[ATTR.MESSAGE_CONTENT_JSON] = val;
             attributes[ATTR.MESSAGE_CONTENT_TYPE] = 'json';
             if (truncated && this.config.markTruncatedContent) {
@@ -444,7 +488,7 @@ export class Eval2OtelConverter {
     evalResult.response.choices.forEach((choice) => {
       const attributes: Record<string, string | number | boolean> = {
         'gen_ai.system': evalResult.system ?? 'unknown',
-        [ATTR.PROVIDER_NAME]: this.getProviderName(evalResult.system) ?? 'unknown',
+        [ATTR.PROVIDER_NAME]: normalizeProviderName(evalResult.system) ?? 'unknown',
         [ATTR.RESPONSE_CHOICE_INDEX]: choice.index,
         [ATTR.RESPONSE_FINISH_REASON]: choice.finishReason,
         [ATTR.MESSAGE_ROLE]: choice.message.role,
@@ -453,7 +497,7 @@ export class Eval2OtelConverter {
       if (choice.message.content !== undefined) {
         if (typeof choice.message.content === 'string') {
           const original = choice.message.content;
-          const redacted = this.redactMessageContent(original, choice.message.role);
+          const redacted = this.trackRedaction(span, original, this.redactMessageContent(original, choice.message.role));
           if (redacted !== null) {
             const max = this.config.contentMaxLength;
             let val = redacted;
@@ -462,6 +506,7 @@ export class Eval2OtelConverter {
               val = redacted.slice(0, max);
               truncated = true;
             }
+            this.trackTruncation(span, truncated);
             attributes[ATTR.MESSAGE_CONTENT] = val;
             attributes[ATTR.MESSAGE_CONTENT_TYPE] = 'text';
             if (truncated && this.config.markTruncatedContent) {
@@ -472,7 +517,7 @@ export class Eval2OtelConverter {
           }
         } else {
           const jsonStr = JSON.stringify(choice.message.content);
-          const redacted = this.redactMessageContent(jsonStr, choice.message.role);
+          const redacted = this.trackRedaction(span, jsonStr, this.redactMessageContent(jsonStr, choice.message.role));
           if (redacted !== null) {
             const max = this.config.contentMaxLength;
             let val = redacted;
@@ -481,6 +526,7 @@ export class Eval2OtelConverter {
               val = redacted.slice(0, max);
               truncated = true;
             }
+            this.trackTruncation(span, truncated);
             attributes[ATTR.MESSAGE_CONTENT_JSON] = val;
             attributes[ATTR.MESSAGE_CONTENT_TYPE] = 'json';
             if (truncated && this.config.markTruncatedContent) {
@@ -505,11 +551,12 @@ export class Eval2OtelConverter {
             [ATTR.TOOL_CALL_ID]: toolCall.id,
             [ATTR.RESPONSE_CHOICE_INDEX]: choice.index,
             [ATTR.TOOL_ARGUMENTS]: this.truncateContent(
-              this.redactToolArguments(
+              this.trackRedaction(span, rawArgs, this.redactToolArguments(
                 rawArgs,
                 toolCall.function.name,
                 toolCall.id
-              ) ?? '{}'
+              )) ?? '{}',
+              span
             ),
             });
           }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,5 +1,10 @@
 import { EvalResult } from './types';
 import {
+  EVAL2OTEL_CONTRACT_VERSION,
+  sha256,
+} from './contract';
+import { ConversionWarning, ProviderConversionResult } from './types';
+import {
   convertOpenAIChatToEval2Otel,
   convertOpenAICompatibleToEval2Otel,
   convertAnthropicToEval2Otel,
@@ -57,6 +62,103 @@ export function convertProviderToEvalResult(
     default:
       return null;
   }
+}
+
+export function convertProviderWithEvidence(payload: {
+  request: unknown;
+  response: unknown;
+  startTime: number;
+  endTime?: number;
+  provider?: ProviderMode | string;
+}): ProviderConversionResult {
+  const { request, response, startTime } = payload;
+  const endTime = payload.endTime ?? startTime + 1;
+  const detected = detectProvider(request, response);
+  const requestedMode = payload.provider?.toString().toLowerCase() as ProviderMode | undefined;
+  const explicitMode = requestedMode && requestedMode !== 'unknown' ? requestedMode : undefined;
+  const mode = explicitMode ?? detected;
+  const warnings: ConversionWarning[] = [];
+
+  if (explicitMode && !isProviderKnown(explicitMode)) {
+    warnings.push({
+      code: 'provider.unsupported',
+      message: `Unsupported provider mode: ${payload.provider}`,
+      severity: 'error',
+    });
+    return {
+      mode: explicitMode,
+      confidence: 'unknown',
+      evalResult: null,
+      warnings,
+      evidence: {
+        rawPayloadSha256: sha256({ request, response }),
+        warningCount: warnings.length,
+        warnings,
+      },
+    };
+  }
+
+  if (!explicitMode && detected === 'unknown') {
+    warnings.push({
+      code: 'provider.autodetect_failed',
+      message: 'Provider payload did not match a supported adapter shape.',
+      severity: 'warning',
+    });
+  }
+
+  const evalResult = convertProviderToEvalResult(
+    request as any,
+    response as any,
+    startTime,
+    endTime,
+    mode,
+  );
+
+  if (!evalResult) {
+    if (!warnings.some(w => w.code === 'provider.autodetect_failed')) {
+      warnings.push({
+        code: 'provider.conversion_failed',
+        message: `Provider conversion returned no EvalResult for mode: ${mode}`,
+        severity: 'error',
+      });
+    }
+    return {
+      mode,
+      confidence: explicitMode ? 'explicit' : (detected === 'unknown' ? 'unknown' : 'detected'),
+      evalResult: null,
+      warnings,
+      evidence: {
+        rawPayloadSha256: sha256({ request, response }),
+        warningCount: warnings.length,
+        warnings,
+      },
+    };
+  }
+
+  const evidence = {
+    ...evalResult.evidence,
+    rawPayloadSha256: evalResult.evidence?.rawPayloadSha256 ?? sha256({ request, response }),
+    warningCount: warnings.length,
+    warnings,
+  };
+
+  return {
+    mode,
+    confidence: explicitMode ? 'explicit' : 'detected',
+    evalResult: {
+      ...evalResult,
+      provenance: {
+        ...evalResult.provenance,
+        sourceFramework: evalResult.provenance?.sourceFramework ?? 'provider-native',
+        adapter: evalResult.provenance?.adapter ?? mode,
+        adapterVersion: evalResult.provenance?.adapterVersion ?? EVAL2OTEL_CONTRACT_VERSION,
+        contractVersion: evalResult.provenance?.contractVersion ?? EVAL2OTEL_CONTRACT_VERSION,
+      },
+      evidence,
+    },
+    warnings,
+    evidence,
+  };
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions'
 
 import { Eval2OtelConverter } from './converter';
 import { Eval2OtelMetrics } from './metrics';
+import { buildFailureConversionReport } from './contract';
 import { EvalResult, OtelConfig, ProcessOptions } from './types';
 
 export class Eval2Otel {
@@ -150,13 +151,17 @@ export class Eval2Otel {
    * Process a single evaluation result with optional additional context
    */
   processEvaluation(evalResult: EvalResult, options?: ProcessOptions): void {
+    const startedAt = Date.now();
     try {
       // Convert to OpenTelemetry spans and events
-      this.converter.convertEvalResult(evalResult, options);
+      const report = this.converter.convertEvalResult(evalResult, options);
       
       // Record metrics
       this.metrics.recordMetrics(evalResult, options);
+      this.metrics.recordConversionTelemetry(evalResult, report);
     } catch (error) {
+      const report = buildFailureConversionReport(evalResult, this.config, error, Date.now() - startedAt);
+      this.metrics.recordConversionTelemetry(evalResult, report);
       console.error('Error processing evaluation:', error);
       throw error; // Re-throw for proper error handling
     }
@@ -215,10 +220,29 @@ export class Eval2Otel {
 }
 
 // Re-export types and classes
-export { EvalResult, OtelConfig, GenAIAttributes, ProcessOptions } from './types';
+export {
+  ConversionReport,
+  ConversionWarning,
+  Eval2OtelEvidence,
+  Eval2OtelProvenance,
+  EvalResult,
+  GenAIAttributes,
+  OtelConfig,
+  ProcessOptions,
+  ProviderConversionResult,
+} from './types';
 export { Eval2OtelConverter } from './converter';
 export { Eval2OtelMetrics } from './metrics';
-export { detectProvider, convertProviderToEvalResult, convertAnyProvider, type ProviderMode } from './helpers';
+export {
+  EVAL2OTEL_CONTRACT_VERSION,
+  UNKNOWN_SEMCONV_VERSION,
+  buildConversionReport,
+  buildEval2OtelAttributes,
+  buildEval2OtelEvidence,
+  normalizeProviderName,
+  sha256,
+} from './contract';
+export { detectProvider, convertProviderToEvalResult, convertProviderWithEvidence, convertAnyProvider, type ProviderMode } from './helpers';
 export { 
   Eval2OtelValidation, 
   ValidationResult, 

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,5 +1,6 @@
-import { metrics, Histogram, Meter, context as otContext } from '@opentelemetry/api';
-import { EvalResult, OtelConfig, ProcessOptions } from './types';
+import { metrics, Counter, Histogram, Meter, context as otContext } from '@opentelemetry/api';
+import { normalizeProviderName } from './contract';
+import { ConversionReport, EvalResult, OtelConfig, ProcessOptions } from './types';
 
 export class Eval2OtelMetrics {
   private meter: Meter;
@@ -30,6 +31,14 @@ export class Eval2OtelMetrics {
   private validationSuccessRateHistogram!: Histogram;
   private validationRetryCountHistogram!: Histogram;
   private validationDurationHistogram!: Histogram;
+
+  // Eval2Otel operational telemetry
+  private conversionCountCounter!: Counter;
+  private conversionDurationHistogram!: Histogram;
+  private conversionWarningCountHistogram!: Histogram;
+  private conversionDroppedEventHistogram!: Histogram;
+  private conversionRedactedContentHistogram!: Histogram;
+  private conversionTruncatedContentHistogram!: Histogram;
 
   constructor(config: OtelConfig) {
     this.config = config;
@@ -118,6 +127,36 @@ export class Eval2OtelMetrics {
       description: 'Time taken for validation including retries',
       unit: 'ms',
     });
+
+    this.conversionCountCounter = this.meter.createCounter('eval2otel.conversion.count', {
+      description: 'Number of eval2otel conversion attempts by status',
+      unit: '{conversion}',
+    });
+
+    this.conversionDurationHistogram = this.meter.createHistogram('eval2otel.conversion.duration', {
+      description: 'Duration of eval2otel conversion work',
+      unit: 'ms',
+    });
+
+    this.conversionWarningCountHistogram = this.meter.createHistogram('eval2otel.conversion.warning_count', {
+      description: 'Number of warnings produced during conversion',
+      unit: '{warning}',
+    });
+
+    this.conversionDroppedEventHistogram = this.meter.createHistogram('eval2otel.conversion.dropped_event_count', {
+      description: 'Number of operational events dropped by conversion guardrails',
+      unit: '{event}',
+    });
+
+    this.conversionRedactedContentHistogram = this.meter.createHistogram('eval2otel.conversion.redacted_content_count', {
+      description: 'Number of message/tool content fields redacted during conversion',
+      unit: '{field}',
+    });
+
+    this.conversionTruncatedContentHistogram = this.meter.createHistogram('eval2otel.conversion.truncated_content_count', {
+      description: 'Number of message/tool content fields truncated during conversion',
+      unit: '{field}',
+    });
   }
 
   /**
@@ -132,7 +171,7 @@ export class Eval2OtelMetrics {
     };
 
     // Provider discriminator aligned with latest GenAI semconv
-    const provider = this.getProviderName(evalResult.system);
+    const provider = normalizeProviderName(evalResult.system);
     if (provider) {
       (baseAttributes as any)['gen_ai.provider.name'] = provider;
     }
@@ -276,15 +315,36 @@ export class Eval2OtelMetrics {
     }
   }
 
-  private getProviderName(system?: string): string | undefined {
-    if (!system) return undefined;
-    const s = system.toLowerCase();
-    if (s.includes('azure')) return 'azure.openai';
-    if (s.includes('bedrock') || s.includes('aws')) return 'aws.bedrock';
-    if (s.includes('vertex') || s.includes('gemini') || s.includes('google')) return 'google.vertex';
-    if (s.includes('anthropic') || s.includes('claude')) return 'anthropic';
-    if (s.includes('openai')) return 'openai';
-    return s;
+  recordConversionTelemetry(evalResult: Partial<EvalResult> | undefined, report: ConversionReport): void {
+    const attrs: Record<string, string | number> = {
+      'evalops.contract.version': report.contractVersion,
+      'evalops.semconv.version': report.semconvVersion,
+      'evalops.conversion.status': report.success ? 'success' : 'failure',
+      'evalops.eval.id': report.evalId,
+    };
+
+    if (evalResult?.operation) {
+      attrs['gen_ai.operation.name'] = evalResult.operation;
+    }
+    if (evalResult?.system) {
+      attrs['gen_ai.system'] = evalResult.system;
+      const provider = normalizeProviderName(evalResult.system);
+      if (provider) attrs['gen_ai.provider.name'] = provider;
+    }
+    if (evalResult?.request?.model) {
+      attrs['gen_ai.request.model'] = evalResult.request.model;
+    }
+    if (report.errorType) {
+      attrs['error.type'] = report.errorType;
+    }
+
+    const prepared = this.filterMetricAttributes(attrs);
+    this.conversionCountCounter.add(1, prepared);
+    this.conversionDurationHistogram.record(report.durationMs, prepared);
+    this.conversionWarningCountHistogram.record(report.warningCount, prepared);
+    this.conversionDroppedEventHistogram.record(report.droppedEventCount, prepared);
+    this.conversionRedactedContentHistogram.record(report.redactedContentCount, prepared);
+    this.conversionTruncatedContentHistogram.record(report.truncatedContentCount, prepared);
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,35 @@
 import { Span, SpanContext } from '@opentelemetry/api';
 import { z } from 'zod';
 
+export const ConversionWarningSchema = z.object({
+  code: z.string(),
+  message: z.string(),
+  severity: z.enum(['info', 'warning', 'error']).optional(),
+});
+
+export const Eval2OtelProvenanceSchema = z.object({
+  sourceFramework: z.string().optional(),
+  runId: z.string().optional(),
+  caseId: z.string().optional(),
+  datasetId: z.string().optional(),
+  datasetVersion: z.string().optional(),
+  adapter: z.string().optional(),
+  adapterVersion: z.string().optional(),
+  contractVersion: z.string().optional(),
+  semconvVersion: z.string().optional(),
+});
+
+export const Eval2OtelEvidenceSchema = z.object({
+  rawPayloadSha256: z.string().optional(),
+  promptSha256: z.string().optional(),
+  responseSha256: z.string().optional(),
+  redactedContentCount: z.number().nonnegative().optional(),
+  truncatedContentCount: z.number().nonnegative().optional(),
+  droppedEventCount: z.number().nonnegative().optional(),
+  warningCount: z.number().nonnegative().optional(),
+  warnings: z.array(ConversionWarningSchema).optional(),
+});
+
 // Zod schema for runtime validation
 export const EvalResultSchema = z.object({
   id: z.string(),
@@ -142,9 +171,41 @@ export const EvalResultSchema = z.object({
     name: z.string().optional(),
     attributes: z.record(z.string(), z.union([z.string(), z.number(), z.boolean(), z.array(z.string())])).optional(),
   }).optional(),
+
+  // Eval2Otel provenance/evidence metadata. These fields are emitted as
+  // namespaced attributes and are intended for auditability, not prompt content.
+  provenance: Eval2OtelProvenanceSchema.optional(),
+  evidence: Eval2OtelEvidenceSchema.optional(),
 });
 
 export type EvalResult = z.infer<typeof EvalResultSchema>;
+export type ConversionWarning = z.infer<typeof ConversionWarningSchema>;
+export type Eval2OtelProvenance = z.infer<typeof Eval2OtelProvenanceSchema>;
+export type Eval2OtelEvidence = z.infer<typeof Eval2OtelEvidenceSchema>;
+
+export interface ConversionReport {
+  evalId: string;
+  success: boolean;
+  contractVersion: string;
+  semconvVersion: string;
+  spanName?: string;
+  eventCount: number;
+  droppedEventCount: number;
+  redactedContentCount: number;
+  truncatedContentCount: number;
+  warningCount: number;
+  warnings: ConversionWarning[];
+  durationMs: number;
+  errorType?: string;
+}
+
+export interface ProviderConversionResult {
+  mode: string;
+  confidence: 'explicit' | 'detected' | 'unknown';
+  evalResult: EvalResult | null;
+  warnings: ConversionWarning[];
+  evidence: Eval2OtelEvidence;
+}
 
 export interface OtelConfig {
   /** Service name for OpenTelemetry */

--- a/test/conformance-contract.test.ts
+++ b/test/conformance-contract.test.ts
@@ -1,0 +1,101 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { Span, trace } from '@opentelemetry/api';
+import { Eval2OtelConverter } from '../src/converter';
+import { EvalResult, OtelConfig } from '../src/types';
+
+class CapturingSpan implements Span {
+  events: Array<{ name: string; attributes: Record<string, unknown> }> = [];
+  attributes: Record<string, unknown> = {};
+
+  addEvent(name: string, attributesOrStartTime?: unknown) {
+    const attrs = typeof attributesOrStartTime === 'object' && attributesOrStartTime !== null
+      ? attributesOrStartTime as Record<string, unknown>
+      : {};
+    this.events.push({ name, attributes: attrs });
+    return this;
+  }
+  setStatus() { return this; }
+  setAttribute(key: string, value: unknown) { this.attributes[key] = value; return this; }
+  setAttributes(attrs: Record<string, unknown>) { Object.assign(this.attributes, attrs); return this; }
+  recordException() { return this; }
+  end() {}
+  spanContext(): any { return {}; }
+  isRecording(): boolean { return true; }
+  updateName(): this { return this; }
+}
+
+class CapturingTracer {
+  started: Array<{ name: string; options: any; span: CapturingSpan }> = [];
+
+  startSpan(name: string, options: any) {
+    const span = new CapturingSpan();
+    this.started.push({ name, options, span });
+    return span as any;
+  }
+}
+
+interface ConformanceFixture {
+  name: string;
+  config?: Partial<OtelConfig>;
+  redactPattern?: string;
+  evalResult: EvalResult;
+  expected: {
+    spanName: string;
+    startAttributes?: Record<string, unknown>;
+    finalAttributes?: Record<string, unknown>;
+    events: Array<{
+      name: string;
+      attributes?: Record<string, unknown>;
+      forbiddenContent?: string;
+    }>;
+  };
+}
+
+function loadFixtures(): ConformanceFixture[] {
+  const dir = path.join(__dirname, 'fixtures', 'conformance');
+  return fs.readdirSync(dir)
+    .filter(file => file.endsWith('.json'))
+    .sort()
+    .map(file => JSON.parse(fs.readFileSync(path.join(dir, file), 'utf8')) as ConformanceFixture);
+}
+
+describe('eval2otel conformance contract', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it.each(loadFixtures())('$name', fixture => {
+    const tracer = new CapturingTracer();
+    jest.spyOn(trace, 'getTracer').mockReturnValue(tracer as any);
+    const config: OtelConfig = {
+      serviceName: 'contract-test',
+      captureContent: false,
+      useSdk: false,
+      ...fixture.config,
+      redact: fixture.redactPattern
+        ? (content: string) => content.replace(new RegExp(fixture.redactPattern!, 'g'), '[REDACTED]')
+        : undefined,
+    };
+
+    const converter = new Eval2OtelConverter(config);
+    const report = converter.convertEvalResult(fixture.evalResult);
+    const started = tracer.started[0];
+
+    expect(started.name).toBe(fixture.expected.spanName);
+    expect(report.spanName).toBe(fixture.expected.spanName);
+    expect(report.success).toBe(true);
+    expect(report.eventCount).toBe(fixture.expected.events.length);
+    expect(started.options.attributes).toEqual(expect.objectContaining(fixture.expected.startAttributes ?? {}));
+    expect(started.span.attributes).toEqual(expect.objectContaining(fixture.expected.finalAttributes ?? {}));
+    expect(started.span.events.map(event => event.name)).toEqual(fixture.expected.events.map(event => event.name));
+
+    fixture.expected.events.forEach((expectedEvent, index) => {
+      const actual = started.span.events[index];
+      expect(actual.attributes).toEqual(expect.objectContaining(expectedEvent.attributes ?? {}));
+      if (expectedEvent.forbiddenContent) {
+        expect(JSON.stringify(actual.attributes)).not.toContain(expectedEvent.forbiddenContent);
+      }
+    });
+  });
+});

--- a/test/fixtures/conformance/chat-redaction.json
+++ b/test/fixtures/conformance/chat-redaction.json
@@ -1,0 +1,99 @@
+{
+  "name": "chat redaction and provenance",
+  "config": {
+    "captureContent": true,
+    "semconvGaVersion": "1.37.0"
+  },
+  "redactPattern": "SECRET-[0-9]+",
+  "evalResult": {
+    "id": "contract-chat-1",
+    "timestamp": 1700000000000,
+    "model": "gpt-4o-mini",
+    "system": "openai",
+    "operation": "chat",
+    "request": {
+      "model": "gpt-4o-mini",
+      "temperature": 0.2,
+      "maxTokens": 128
+    },
+    "response": {
+      "id": "resp-contract-chat-1",
+      "model": "gpt-4o-mini",
+      "finishReasons": ["stop"],
+      "choices": [{
+        "index": 0,
+        "finishReason": "stop",
+        "message": {
+          "role": "assistant",
+          "content": "Final answer includes SECRET-456."
+        }
+      }]
+    },
+    "usage": {
+      "inputTokens": 12,
+      "outputTokens": 8,
+      "totalTokens": 20
+    },
+    "performance": {
+      "duration": 1.25
+    },
+    "conversation": {
+      "id": "conv-contract-1",
+      "messages": [{
+        "role": "user",
+        "content": "Please answer without leaking SECRET-123."
+      }]
+    },
+    "provenance": {
+      "sourceFramework": "promptfoo",
+      "runId": "run-2026-05-18",
+      "caseId": "case-redaction",
+      "datasetId": "evalops-core",
+      "datasetVersion": "2026.05"
+    },
+    "evidence": {
+      "warnings": [{
+        "code": "fixture.notice",
+        "message": "Fixture carries one warning so warning_count is contract-tested.",
+        "severity": "info"
+      }]
+    }
+  },
+  "expected": {
+    "spanName": "gen_ai.chat",
+    "startAttributes": {
+      "evalops.contract.version": "eval2otel.v1",
+      "evalops.semconv.version": "1.37.0",
+      "evalops.eval.id": "contract-chat-1",
+      "evalops.source.framework": "promptfoo",
+      "evalops.run.id": "run-2026-05-18",
+      "evalops.case.id": "case-redaction",
+      "evalops.dataset.id": "evalops-core",
+      "evalops.dataset.version": "2026.05",
+      "evalops.warning_count": 1,
+      "gen_ai.provider.name": "openai",
+      "gen_ai.operation.name": "chat",
+      "gen_ai.request.model": "gpt-4o-mini"
+    },
+    "finalAttributes": {
+      "evalops.redacted_content_count": 2,
+      "evalops.truncated_content_count": 0,
+      "evalops.dropped_event_count": 0
+    },
+    "events": [{
+      "name": "gen_ai.user.message",
+      "attributes": {
+        "gen_ai.message.content": "Please answer without leaking [REDACTED].",
+        "gen_ai.message.content_type": "text"
+      },
+      "forbiddenContent": "SECRET-123"
+    }, {
+      "name": "gen_ai.assistant.message",
+      "attributes": {
+        "gen_ai.message.content": "Final answer includes [REDACTED].",
+        "gen_ai.response.finish_reason": "stop"
+      },
+      "forbiddenContent": "SECRET-456"
+    }]
+  }
+}

--- a/test/fixtures/conformance/event-cap-rag.json
+++ b/test/fixtures/conformance/event-cap-rag.json
@@ -1,0 +1,93 @@
+{
+  "name": "event cap records dropped RAG metadata",
+  "config": {
+    "captureContent": true,
+    "maxEventsPerSpan": 2
+  },
+  "evalResult": {
+    "id": "contract-rag-cap-1",
+    "timestamp": 1700000001000,
+    "model": "gpt-4o-mini",
+    "system": "azure-openai",
+    "operation": "chat",
+    "request": {
+      "model": "gpt-4o-mini"
+    },
+    "response": {
+      "choices": [{
+        "index": 0,
+        "finishReason": "stop",
+        "message": {
+          "role": "assistant",
+          "content": "grounded answer"
+        }
+      }]
+    },
+    "usage": {
+      "inputTokens": 44,
+      "outputTokens": 12
+    },
+    "performance": {
+      "duration": 0.75
+    },
+    "conversation": {
+      "id": "conv-rag-cap",
+      "messages": [{
+        "role": "system",
+        "content": "answer with citations"
+      }, {
+        "role": "user",
+        "content": "what did the release say?"
+      }]
+    },
+    "rag": {
+      "retrievalMethod": "hybrid",
+      "documentsRetrieved": 3,
+      "documentsUsed": 2,
+      "chunks": [{
+        "id": "chunk-a",
+        "source": "release-notes.md",
+        "relevanceScore": 0.92,
+        "position": 0
+      }, {
+        "id": "chunk-b",
+        "source": "contract.md",
+        "relevanceScore": 0.86,
+        "position": 1
+      }],
+      "metrics": {
+        "contextPrecision": 0.8,
+        "contextRecall": 0.7,
+        "answerRelevance": 0.9,
+        "faithfulness": 0.95
+      }
+    }
+  },
+  "expected": {
+    "spanName": "gen_ai.chat",
+    "startAttributes": {
+      "gen_ai.provider.name": "azure.openai",
+      "gen_ai.rag.retrieval_method": "hybrid",
+      "gen_ai.rag.documents_retrieved": 3,
+      "gen_ai.rag.context_precision": 0.8
+    },
+    "finalAttributes": {
+      "evalops.dropped_event_count": 3,
+      "evalops.redacted_content_count": 0,
+      "evalops.truncated_content_count": 0
+    },
+    "events": [{
+      "name": "gen_ai.system.message",
+      "attributes": {
+        "gen_ai.message.index": 0,
+        "gen_ai.message.content": "answer with citations"
+      }
+    }, {
+      "name": "gen_ai.user.message",
+      "attributes": {
+        "gen_ai.message.index": 1,
+        "gen_ai.message.content": "what did the release say?"
+      }
+    }]
+  }
+}

--- a/test/fixtures/conformance/tool-provenance.json
+++ b/test/fixtures/conformance/tool-provenance.json
@@ -1,0 +1,94 @@
+{
+  "name": "tool execution provenance and argument truncation",
+  "config": {
+    "captureContent": true,
+    "contentMaxLength": 18,
+    "markTruncatedContent": true
+  },
+  "evalResult": {
+    "id": "contract-tool-1",
+    "timestamp": 1700000002000,
+    "model": "claude-3-5-sonnet",
+    "system": "anthropic",
+    "operation": "execute_tool",
+    "request": {
+      "model": "claude-3-5-sonnet"
+    },
+    "response": {
+      "choices": [{
+        "index": 0,
+        "finishReason": "tool_calls",
+        "message": {
+          "role": "assistant",
+          "toolCalls": [{
+            "id": "tool-call-1",
+            "type": "function",
+            "function": {
+              "name": "lookup_policy",
+              "arguments": {
+                "customer": "evalops",
+                "query": "show me the full retention policy"
+              }
+            }
+          }]
+        }
+      }]
+    },
+    "usage": {
+      "inputTokens": 18,
+      "outputTokens": 4
+    },
+    "performance": {
+      "duration": 0.42
+    },
+    "tool": {
+      "name": "lookup_policy",
+      "callId": "tool-call-1"
+    },
+    "provenance": {
+      "sourceFramework": "deepeval",
+      "runId": "run-tool-1",
+      "caseId": "case-tool",
+      "adapter": "anthropic",
+      "adapterVersion": "eval2otel.v1",
+      "contractVersion": "eval2otel.v1"
+    },
+    "evidence": {
+      "rawPayloadSha256": "raw-payload-hash-from-adapter",
+      "promptSha256": "prompt-hash-from-adapter",
+      "responseSha256": "response-hash-from-adapter"
+    }
+  },
+  "expected": {
+    "spanName": "gen_ai.execute_tool",
+    "startAttributes": {
+      "evalops.source.framework": "deepeval",
+      "evalops.adapter.name": "anthropic",
+      "evalops.adapter.version": "eval2otel.v1",
+      "evalops.raw_payload_sha256": "raw-payload-hash-from-adapter",
+      "evalops.prompt_sha256": "prompt-hash-from-adapter",
+      "evalops.response_sha256": "response-hash-from-adapter",
+      "gen_ai.provider.name": "anthropic",
+      "gen_ai.tool.name": "lookup_policy",
+      "gen_ai.tool.call.id": "tool-call-1"
+    },
+    "finalAttributes": {
+      "evalops.dropped_event_count": 0,
+      "evalops.redacted_content_count": 0,
+      "evalops.truncated_content_count": 1
+    },
+    "events": [{
+      "name": "gen_ai.tool.message",
+      "attributes": {
+        "gen_ai.tool.name": "lookup_policy",
+        "gen_ai.tool.call.id": "tool-call-1",
+        "gen_ai.tool.arguments": "{\"customer\":\"evalo"
+      }
+    }, {
+      "name": "gen_ai.assistant.message",
+      "attributes": {
+        "gen_ai.response.finish_reason": "tool_calls"
+      }
+    }]
+  }
+}

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -1,4 +1,11 @@
-import { detectProvider, convertProviderToEvalResult, convertAnyProvider, isProviderKnown, listSupportedProviders } from '../src/helpers';
+import {
+  detectProvider,
+  convertProviderToEvalResult,
+  convertProviderWithEvidence,
+  convertAnyProvider,
+  isProviderKnown,
+  listSupportedProviders,
+} from '../src/helpers';
 
 describe('helpers: detectProvider / convertProviderToEvalResult', () => {
   it('detects openai-chat and converts to EvalResult', () => {
@@ -97,6 +104,46 @@ describe('helpers: detectProvider / convertProviderToEvalResult', () => {
     expect(isProviderKnown('unknown')).toBe(false);
     const list = listSupportedProviders();
     expect(list).toContain('vertex');
+  });
+
+  it('convertProviderWithEvidence enriches adapter provenance and raw payload hash', () => {
+    const start = Date.now();
+    const request = { model: 'gpt-4o-mini', messages: [{ role: 'user', content: 'hi' }] };
+    const response = {
+      object: 'chat.completion',
+      id: 'chatcmpl-1',
+      model: 'gpt-4o-mini',
+      choices: [{ index: 0, finish_reason: 'stop', message: { role: 'assistant', content: 'hello' } }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    };
+
+    const result = convertProviderWithEvidence({
+      request,
+      response,
+      startTime: start,
+      endTime: start + 1000,
+      provider: 'openai-chat',
+    });
+
+    expect(result.confidence).toBe('explicit');
+    expect(result.evalResult?.provenance?.adapter).toBe('openai-chat');
+    expect(result.evalResult?.provenance?.contractVersion).toBe('eval2otel.v1');
+    expect(result.evalResult?.evidence?.rawPayloadSha256).toMatch(/^[a-f0-9]{64}$/);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('convertProviderWithEvidence reports unsupported provider modes', () => {
+    const result = convertProviderWithEvidence({
+      request: {},
+      response: {},
+      startTime: Date.now(),
+      provider: 'mystery-provider',
+    });
+
+    expect(result.evalResult).toBeNull();
+    expect(result.confidence).toBe('unknown');
+    expect(result.warnings[0].code).toBe('provider.unsupported');
+    expect(result.evidence.warningCount).toBe(1);
   });
 
 });

--- a/test/index-exports.test.ts
+++ b/test/index-exports.test.ts
@@ -7,5 +7,26 @@ describe('Package exports', () => {
     expect(pkg.Eval2OtelConverter).toBeDefined();
     expect(pkg.Eval2OtelMetrics).toBeDefined();
   });
-});
 
+  it('exports contract helpers and provider adapters from the root entrypoint', () => {
+    expect(pkg.EVAL2OTEL_CONTRACT_VERSION).toBe('eval2otel.v1');
+    expect(pkg.UNKNOWN_SEMCONV_VERSION).toBe('unspecified');
+    expect(pkg.buildConversionReport).toBeDefined();
+    expect(pkg.buildEval2OtelAttributes).toBeDefined();
+    expect(pkg.buildEval2OtelEvidence).toBeDefined();
+    expect(pkg.normalizeProviderName('azure-openai')).toBe('azure.openai');
+    expect(pkg.sha256('x')).toMatch(/^[a-f0-9]{64}$/);
+    expect(pkg.detectProvider).toBeDefined();
+    expect(pkg.convertProviderToEvalResult).toBeDefined();
+    expect(pkg.convertProviderWithEvidence).toBeDefined();
+    expect(pkg.convertAnyProvider).toBeDefined();
+    expect(pkg.convertOllamaToEval2Otel).toBeDefined();
+    expect(pkg.convertOpenAICompatibleToEval2Otel).toBeDefined();
+    expect(pkg.convertBedrockToEval2Otel).toBeDefined();
+    expect(pkg.convertAzureOpenAIToEval2Otel).toBeDefined();
+    expect(pkg.convertVertexToEval2Otel).toBeDefined();
+    expect(pkg.convertAnthropicToEval2Otel).toBeDefined();
+    expect(pkg.convertCohereToEval2Otel).toBeDefined();
+    expect(pkg.convertOpenAIChatToEval2Otel).toBeDefined();
+  });
+});

--- a/test/metrics-counters.test.ts
+++ b/test/metrics-counters.test.ts
@@ -31,5 +31,35 @@ describe('Metrics counters and histograms', () => {
     expect(meter.histograms.has('eval.accuracy')).toBe(true);
     expect(meter.histograms.get('eval.accuracy')!.records[0].value).toBe(0.9);
   });
-});
 
+  it('records eval2otel conversion operational telemetry', () => {
+    const meter = new FakeMeter();
+    jest.spyOn(otMetrics, 'getMeter').mockReturnValue(meter as any);
+    const m = new Eval2OtelMetrics({ serviceName: 'svc' });
+    const evalResult: EvalResult = {
+      id: 'm3', timestamp: Date.now(), model: 'gpt-4', system: 'openai', operation: 'chat',
+      request: { model: 'gpt-4' }, response: {}, usage: {}, performance: { duration: 1 },
+    } as any;
+
+    m.recordConversionTelemetry(evalResult, {
+      evalId: 'm3',
+      success: true,
+      contractVersion: 'eval2otel.v1',
+      semconvVersion: '1.37.0',
+      spanName: 'gen_ai.chat',
+      eventCount: 2,
+      droppedEventCount: 1,
+      redactedContentCount: 1,
+      truncatedContentCount: 1,
+      warningCount: 0,
+      warnings: [],
+      durationMs: 12,
+    });
+
+    expect(meter.counters.get('eval2otel.conversion.count')!.adds[0].value).toBe(1);
+    expect(meter.histograms.get('eval2otel.conversion.duration')!.records[0].value).toBe(12);
+    expect(meter.histograms.get('eval2otel.conversion.dropped_event_count')!.records[0].value).toBe(1);
+    expect(meter.histograms.get('eval2otel.conversion.redacted_content_count')!.records[0].value).toBe(1);
+    expect(meter.histograms.get('eval2otel.conversion.truncated_content_count')!.records[0].value).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a durable `eval2otel.v1` telemetry contract and makes it executable with golden conformance fixtures. This turns span/event/privacy/provenance behavior into something CI can protect instead of relying on README intent.

## What changed

- Added `docs/contract/eval2otel-v1.md` and fixture-backed conformance tests for redaction/provenance, RAG event caps, and tool argument truncation.
- Added optional `EvalResult.provenance` and `EvalResult.evidence` fields, emitted as `evalops.*` attributes on spans.
- Made the converter return a `ConversionReport` with dropped event, redaction, truncation, warning, and duration counts.
- Added eval2otel self-telemetry metrics for conversion count/duration/warnings/dropped/redacted/truncated content.
- Added `convertProviderWithEvidence` so provider-native conversions return structured warnings and adapter evidence.
- Hardened npm publishing with package smoke validation and `npm publish --provenance`.

## Issue coverage

Closes #31
Closes #32
Closes #34
Closes #35
Refs #33
Refs #4

## Validation

- `npm run build`
- `npm test`
- `npm run lint` (passes with existing no-explicit-any warnings)
- `npm pack --dry-run`
- local tarball install smoke requiring `createEval2Otel` and `EVAL2OTEL_CONTRACT_VERSION`
