### PR TITLE
Add Python CI guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,3 +79,28 @@ jobs:
 
       - name: Package (dry run)
         run: npm pack --dry-run
+
+  python:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.12']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: python/pyproject.toml
+
+      - name: Install Python package with extras
+        run: python -m pip install -e "python[otel,validation]"
+
+      - name: Test Python package
+        run: PYTHONPATH=python python -m unittest discover -s python/tests
+
+      - name: Python package metadata smoke
+        run: python -m pip install -e python --dry-run


### PR DESCRIPTION
## Summary
- Add a dedicated Python CI job for the SDK preview on Python 3.9 and 3.12.
- Install the package with `otel` and `validation` extras so optional auto-instrumentation and Pydantic paths are exercised.
- Run Python unit tests and pip editable metadata smoke on every PR/main build.

## Test plan
- PYTHONPATH=python python3 -m unittest discover -s python/tests
- python3 -m pip install -e python --dry-run
- parsed `.github/workflows/ci.yml` with PyYAML

Refs #2